### PR TITLE
Add compilation and installation steps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,3 +179,39 @@ Do your best to follow the clean code guidelines.
 - Don’t return an error code, throw an exception instead.
 
 Ref: Book: Clean Code by Robert C. Martin (Uncle Bob)
+
+## Installing and Compiling
+This guide will walk you through the process of installing and compiling nmstate from the source. For installing stable release or other installation methods, please refer to nmstate installation guide: https://nmstate.io/user/install.md
+
+### Prerequisite 
+A Linux operating system is required. For Windows or macOS users, you can set up a Linux environment using VirtualBox, VMware, or Virt-manager.
+
+### Install Cargo Tool
+Cargo is Rust's build system and package manager, necessary for working with Rust programs, such as Nmstate.
+```
+- sudo apt update && sudo apt install cargo git # Debian/Ubuntu
+- sudo dnf install cargo git # Fedora
+- sudo yum install cargo git # RHEL
+```
+
+### Get the Source Code
+Clone the Nmstate repository: 
+```
+- git clone https://github.com/nmstate/nmstate.git
+- cd nmstate
+```
+
+### Compilation
+Navigate to the rust directory and compile the project:
+```
+- cd rust
+- cargo build
+```
+
+### Running the Compiled Program
+After successful compilation, you can run the nmstatectl tool to display the current network state:
+```
+- target/debug/nmstatectl show # To dump the state in json format, use the ‘–json’ flag.
+``` 
+
+For the complete developer’s guide, head over to our full documentation: https://nmstate.io/devel/dev_guide.html 


### PR DESCRIPTION
This commit adds a concise yet comprehensive guide for compiling and installing nmstate from source. It includes instructions for setting up the development environment on Linux, installing Rust's Cargo, and steps to install and compile the project.

The guide targets new contributors to ensure they can easily set up their development environment and start contributing to the project. 

- Added prerequisite information for different operating systems
- Provided installation commands for Cargo on various Linux distributions
- Included steps for cloning the repository and compiling the code
- Described how to run the compiled 'nmstatectl' tool

Resolves: #2600